### PR TITLE
Add Power Attribute to Sensor

### DIFF
--- a/custom_components/ideenergy/sensor.py
+++ b/custom_components/ideenergy/sensor.py
@@ -126,10 +126,10 @@ class Accumulated(RestoreEntity, SensorEntity):
         return DEVICE_CLASS_ENERGY
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self):            
         return {
-            # ATTR_LAST_RESET: self.last_reset,
             ATTR_STATE_CLASS: self.state_class,
+            "Last Power Reading": self._instant,
         }
 
     # @property


### PR DESCRIPTION
Adding the power retrieved from the last reading as an attribute to the sensor. This implementation (instead of a separate sensor) does not require an additional query to the REST API

TO-DO: 
* Change the attribute name to incorporate into translation 
* Set a standard name for templating
* Add Units (currently value is retrieved in W)