### PR TITLE
Propose DEFAULT_NAME change

### DIFF
--- a/custom_components/ideenergy/const.py
+++ b/custom_components/ideenergy/const.py
@@ -19,7 +19,7 @@
 
 
 DOMAIN = "ideenergy"
-DEFAULT_NAME = "ICP"
+DEFAULT_NAME = "I-DE"
 
 CONF_CONTRACT = "contract"
 DELAY_MAX_SECONDS = 5


### PR DESCRIPTION
ICP name might lead to misunderstandings with the fuse box. Proposing using I-DE as default