### PR TITLE
Fix deprecated call to async_add_job

### DIFF
--- a/custom_components/ideenergy/__init__.py
+++ b/custom_components/ideenergy/__init__.py
@@ -100,7 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            hass.async_add_job(
+            hass.async_create_task(
                 hass.config_entries.async_forward_entry_setup(entry, platform)
             )
 


### PR DESCRIPTION
Fix deprecated call to async_add_job. See https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job