### PR TITLE
Implement feature for last day readings only

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -12,19 +12,19 @@
 
 [ideenergy](https://github.com/ldotlopez/ideenergy) integration for [home-assistant](https://home-assistant.io/)
 
-Esta integración provee sensores para el distribuidor de energía español [i-DE](i-de.es).
+Esta integración proporciona sensores para el distribuidor de energía español [i-DE](https://i-de.es).
 
-Require de un usuario **avanzado** en la página web del distribuidor.
+Requiere un usuario **avanzado** en la página web del distribuidor.
 
-**⚠️ Asegurese de leer la [FAQ](https://github.com/ldotlopez/ha-ideenergy/blob/main/FAQ.md)' y las secciones 'advertencias' y 'dependencias'.**
+**⚠️ Asegúrese de leer la [FAQ](https://github.com/ldotlopez/ha-ideenergy/blob/main/FAQ.md) y las secciones 'Advertencias' y 'Dependencias'.**
 
 ## Características
 
-* Integración con el panel del energía de Home Assistant
+* Integración con el panel de energía de Home Assistant.
 
 * Datos de consumo diario por franjas horarias (24 lecturas del día anterior).
 
-* Sensores históricos (consumulo y generación solar) con mayor precisión (sub-kWh). Estos datos no son tiempo real y normalmente llevan un retraso de entre 24 y 48 horas.
+* Sensores históricos (consumo y generación solar) con mayor precisión (sub-kWh). Estos datos no son en tiempo real y normalmente llevan un retraso de entre 24 y 48 horas.
 
 * Nuevas entidades en el dispositivo:
   * Consumo total de ayer.
@@ -34,7 +34,7 @@ Require de un usuario **avanzado** en la página web del distribuidor.
 
 * Soporte para varios contratos (puntos de servicio).
 
-* Configuración a través del [interfaz web de Home Assistant](https://developers.home-assistant.io/docs/config_entries_options_flow_handler) sin necesidad de editar ficheros YAML.
+* Configuración a través de la [interfaz web de Home Assistant](https://developers.home-assistant.io/docs/config_entries_options_flow_handler), sin necesidad de editar ficheros YAML.
 
 * La obtención de datos del API de i-DE se realiza solo al arrancar la integración y una vez al día a las 12:30, cuando normalmente ya están disponibles los datos del día anterior.
 
@@ -47,10 +47,10 @@ Esta adaptación deja de obtener el consumo instantáneo del contador. Para una 
 Ahora la integración obtiene el consumo del día anterior por franja horaria (24 lecturas). Esta información suele estar disponible a partir de las 10:00 del día siguiente, por eso la lectura se programa a las 12:30 para tener margen.
 
 
-## Dependencies
+## Dependencias
 
 Es necesario disponer de acceso al área de clientes de i-DE.
-Puedes registrarte en el siguiente link: [Área Clientes | I-DE - Grupo Iberdrola](https://www.i-de.es/consumidores/web/guest/login).
+Puedes registrarte en el siguiente enlace: [Área Clientes | I-DE - Grupo Iberdrola](https://www.i-de.es/consumidores/web/guest/login).
 
 Además es necesario disponer del perfil de "Usuario avanzado". Si no se dispone de él hay que rellenar un formulario del [Perfil de cliente](https://www.i-de.es/consumidores/web/home/personal-area/userData).
 
@@ -75,7 +75,7 @@ Además es necesario disponer del perfil de "Usuario avanzado". Si no se dispone
   - (Opción B) Navega a "Ajustes" → "Dispositivos y servicios" y pulsa "Añadir integración". Elige "i-DE.es sensores de energía".  
     ![image](https://user-images.githubusercontent.com/59612788/171966005-e58f6b88-a952-4033-82c6-b1d4ea665873.png)
 
-5. Sigue los pasos del asistente: Proporciona tus credenciales de acceso para el área de cliente de "i-DE", después elige el contrato qu deseas monitorizar. Si necesitas añadir más contratos repite los pasos anteriores para cada uno de ellos.
+5. Sigue los pasos del asistente: proporciona tus credenciales de acceso para el área de cliente de i-DE y, después, elige el contrato que deseas monitorizar. Si necesitas añadir más contratos, repite los pasos anteriores para cada uno de ellos.
 
 ## Instalación
 
@@ -93,7 +93,7 @@ A través de custom_components o [HACS](https://hacs.xyz/)
   - (Opción B) Navega a "Ajustes" → "Dispositivos y servicios" y pulsa "Añadir integración". Elige "i-DE.es sensores de energía".  
     ![image](https://user-images.githubusercontent.com/59612788/171966005-e58f6b88-a952-4033-82c6-b1d4ea665873.png)
 
-5. Sigue los pasos del asistente: Proporciona tus credenciales de acceso para el área de cliente de "i-DE", después elige el contrato qu deseas monitorizar. Si necesitas añadir más contratos repite los pasos anteriores para cada uno de ellos.
+5. Sigue los pasos del asistente: proporciona tus credenciales de acceso para el área de cliente de i-DE y, después, elige el contrato que deseas monitorizar. Si necesitas añadir más contratos, repite los pasos anteriores para cada uno de ellos.
 
 ## Capturas
 
@@ -115,4 +115,4 @@ A través de custom_components o [HACS](https://hacs.xyz/)
 ## Advertencias
 Esta integración provee un sensor 'histórico' que incorpora datos del pasado en la base de datos de Home Assistant. Por su propia seguridad este sensor no está habilitado y debe activarse manualmente.
 
-☠️ El sensor histórico está basado en un **hack extremadamente experimental** y puede romper y/o corromper su base de datos y/o estadísticas. **Use lo bajo su propio riesgo**.
+☠️ El sensor histórico está basado en un **hack extremadamente experimental** y puede romper y/o corromper su base de datos y/o estadísticas. **Úselo bajo su propio riesgo**.

--- a/README.es.md
+++ b/README.es.md
@@ -22,17 +22,29 @@ Require de un usuario **avanzado** en la página web del distribuidor.
 
 * Integración con el panel del energía de Home Assistant
 
-* Sensores de consumo instantaneo y acumulado.
+* Datos de consumo diario por franjas horarias (24 lecturas del día anterior).
 
 * Sensores históricos (consumulo y generación solar) con mayor precisión (sub-kWh). Estos datos no son tiempo real y normalmente llevan un retraso de entre 24 y 48 horas.
+
+* Nuevas entidades en el dispositivo:
+  * Consumo total de ayer.
+  * Fecha de última recarga del consumo.
+
+* Se envía una notificación a Home Assistant con el resultado de la llamada al API de i-DE.
 
 * Soporte para varios contratos (puntos de servicio).
 
 * Configuración a través del [interfaz web de Home Assistant](https://developers.home-assistant.io/docs/config_entries_options_flow_handler) sin necesidad de editar ficheros YAML.
 
-* Algoritmo de actualización para leer el contador cerca del final de cada periodo horario (entre el minuto 50 y 59) y una mejor representación del consumo en el panel de energía de Home Assistant
+* La obtención de datos del API de i-DE se realiza solo al arrancar la integración y una vez al día a las 12:30, cuando normalmente ya están disponibles los datos del día anterior.
 
 * Totalmente [asíncrono](https://developers.home-assistant.io/docs/asyncio_index) e integrado en Home Assistant.
+
+## Notas de la adaptación
+
+Esta adaptación deja de obtener el consumo instantáneo del contador. Para una lectura en tiempo real era necesario realizar varias llamadas, esperar a que la lectura estuviera disponible y mantener una sesión con comportamiento frágil durante 24 horas.
+
+Ahora la integración obtiene el consumo del día anterior por franja horaria (24 lecturas). Esta información suele estar disponible a partir de las 10:00 del día siguiente, por eso la lectura se programa a las 12:30 para tener margen.
 
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -23,18 +23,29 @@ This integration requires an **advanced** user profile on i-DE website.
 
 * Integration with the Home Assistant Energy Panel.
 
-* Accumulated and Instant consumption sensors.
+* Daily consumption data by hourly slots (24 readings from the previous day).
 
 * Historical sensors (both consumption and solar generation) with better (sub-kWh) precision. This data is not realtime and usually has a 24-hour to 48-hour offset.
+
+* New device entities:
+  * Total consumption of yesterday.
+  * Last consumption refresh date.
+
+* A Home Assistant notification is sent with the result of the i-DE API call.
 
 * Support for multiple contracts (service points).
 
 * Configuration through [Home Assistant Interface](https://developers.home-assistant.io/docs/config_entries_options_flow_handler) without the need to edit YAML files.
 
-* Update algorithm to read the meter near the end of each hourly period (between minute 50 and 59)
-with a better representation of consumption in the Home Assistant energy panel.
+* API data retrieval is scheduled only at integration startup and once per day at 12:30, when previous-day data is expected to be available.
 
 * Fully [asynchronous](https://developers.home-assistant.io/docs/asyncio_index) and integrated with HomeAssistant.
+
+## Adaptation notes
+
+This adaptation no longer reads instant meter consumption. Real-time readings required multiple calls, waiting for data readiness, and handling fragile 24-hour session behavior.
+
+The integration now reads previous-day consumption by hourly slots (24 values). This information is usually available after 10:00 the next day, so data retrieval is executed at 12:30 to provide additional margin.
 
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ i-DE (Iberdrola Distribución) Custom Integration for Home Assistant, providing 
 
 This integration requires an **advanced** user profile on i-DE website.
 
-**⚠️ Make sure to read the '[FAQ](https://github.com/ldotlopez/ha-ideenergy/blob/main/FAQ.md)', 'Dependencies' and 'Warning' sections**
+**⚠️ Make sure to read the '[FAQ](https://github.com/ldotlopez/ha-ideenergy/blob/main/FAQ.md)', 'Dependencies', and 'Warnings' sections.**
 
 
 ## Features
@@ -25,7 +25,7 @@ This integration requires an **advanced** user profile on i-DE website.
 
 * Daily consumption data by hourly slots (24 readings from the previous day).
 
-* Historical sensors (both consumption and solar generation) with better (sub-kWh) precision. This data is not realtime and usually has a 24-hour to 48-hour offset.
+* Historical sensors (both consumption and solar generation) with better (sub-kWh) precision. This data is not real-time and usually has a 24-hour to 48-hour offset.
 
 * New device entities:
   * Total consumption of yesterday.
@@ -39,7 +39,7 @@ This integration requires an **advanced** user profile on i-DE website.
 
 * API data retrieval is scheduled only at integration startup and once per day at 12:30, when previous-day data is expected to be available.
 
-* Fully [asynchronous](https://developers.home-assistant.io/docs/asyncio_index) and integrated with HomeAssistant.
+* Fully [asynchronous](https://developers.home-assistant.io/docs/asyncio_index) and integrated with Home Assistant.
 
 ## Adaptation notes
 
@@ -50,9 +50,9 @@ The integration now reads previous-day consumption by hourly slots (24 values). 
 
 ## Dependencies
 
-You must have an i-DE username and access to the Clients' website. You may register here: [Área Clientes | I-DE - Grupo Iberdrola](https://www.i-de.es/consumidores/web/guest/login).
+You must have an i-DE username and access to the client website. You may register here: [Área Clientes | I-DE - Grupo Iberdrola](https://www.i-de.es/consumidores/web/guest/login).
 
-It also necessary to have an "Advanced User" profile. Should you not have one already, you need to fill the request for from your [Profile Area](https://www.i-de.es/consumidores/web/home/personal-area/userData).
+It is also necessary to have an "Advanced User" profile. If you do not already have one, you need to submit the request form from your [Profile Area](https://www.i-de.es/consumidores/web/home/personal-area/userData).
 
 
 ## Installation
@@ -64,11 +64,11 @@ It also necessary to have an "Advanced User" profile. Should you not have one al
 2. In the HACS section, add this repository as a custom one:
 
 
-  - On the "repositorysitory" field put the URL copied before
+  - In the "Repository" field, paste the URL copied before.
   - On the "Category" select "Integration"
-  - Click the "Download" button and download latest version.
+  - Click the "Download" button and download the latest version.
 
-  ![Custom repositorysitory](https://user-images.githubusercontent.com/59612788/171965822-4a89c14e-9eb2-4134-8de2-1d3f380663e4.png)
+  ![Custom repository](https://user-images.githubusercontent.com/59612788/171965822-4a89c14e-9eb2-4134-8de2-1d3f380663e4.png)
 
 3. Restart HA
 
@@ -86,7 +86,7 @@ It also necessary to have an "Advanced User" profile. Should you not have one al
 
 1. Download/clone this repository: [https://github.com/ldotlopez/ha-ideenergy](https://github.com/ldotlopez/ha-ideenergy/)
 
-2. Copy the `custom_components/ideenergy` folder into your custom_components folder into your HA installation
+2. Copy the `custom_components/ideenergy` folder into the `custom_components` folder of your Home Assistant installation.
 
 3. Restart HA
 
@@ -114,9 +114,9 @@ It also necessary to have an "Advanced User" profile. Should you not have one al
 ![snapshot](screenshots/configuration-2.png)
 
 ## Warnings
-This extension provides an 'historical' sensor to incorporate data from the past into Home Assistant database. For your own safety the sensor is not enabled by default and must be enabled manually.
+This extension provides a 'historical' sensor to incorporate data from the past into the Home Assistant database. For your own safety, the sensor is not enabled by default and must be enabled manually.
 
-☠️ Historic sensor is based on a **high experimental hack** and can broke and/or corrupt your database and/or statistics. **Use at your own risk**.
+☠️ The historical sensor is based on a **highly experimental hack** and can break and/or corrupt your database and/or statistics. **Use at your own risk**.
 
 ## License
 

--- a/custom_components/ideenergy/__init__.py
+++ b/custom_components/ideenergy/__init__.py
@@ -25,9 +25,10 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.event import async_track_time_change
 from homeassistant.loader import async_get_loaded_integration
 
-from .const import CONF_CONTRACT, DOMAIN, UPDATE_INTERVAL
+from .const import CONF_CONTRACT, DOMAIN, LOCAL_TZ, UPDATE_HOUR, UPDATE_MINUTE
 from .coordinator import IDeEnergyDataCoordinator
 from .data import IntegrationIDeEnergyConfigEntry, IntegrationIDeEnergyRunTimeData
 from .store import IDeEnergyConfigEntryState
@@ -70,11 +71,14 @@ async def async_setup_entry(
     ##
     # Setup coordinator
     # https://developers.home-assistant.io/docs/integration_fetching_data
+    # update_interval=None disables automatic polling; a daily time trigger is
+    # registered below so the fetch runs at a predictable hour when i-DE data
+    # is guaranteed to be available (avoids early-morning "no data yet" errors).
     coordinator = IDeEnergyDataCoordinator(
         hass=hass,
         client=client,
         config_entry_state=config_entry_state,
-        update_interval=UPDATE_INTERVAL,
+        update_interval=None,
     )
     await coordinator.async_config_entry_first_refresh()
     if not coordinator.last_update_success:
@@ -87,6 +91,26 @@ async def async_setup_entry(
         # config_entry_state=config_entry_state,
         integration=async_get_loaded_integration(hass, entry.domain),
         device_info=device_info,
+    )
+
+    ##
+    # Schedule daily refresh at UPDATE_HOUR:UPDATE_MINUTE (local time)
+    def _schedule_daily_refresh(now=None) -> None:  # noqa: ARG001
+        LOGGER.debug(
+            "Scheduled daily refresh triggered at %s:%02d (Europe/Madrid)",
+            UPDATE_HOUR,
+            UPDATE_MINUTE,
+        )
+        hass.async_create_task(coordinator.async_request_refresh())
+
+    entry.async_on_unload(
+        async_track_time_change(
+            hass,
+            _schedule_daily_refresh,
+            hour=UPDATE_HOUR,
+            minute=UPDATE_MINUTE,
+            second=0,
+        )
     )
 
     ##

--- a/custom_components/ideenergy/const.py
+++ b/custom_components/ideenergy/const.py
@@ -16,7 +16,6 @@
 # USA.
 
 
-from datetime import timedelta
 from zoneinfo import ZoneInfo
 
 CONF_CONTRACT = "contract"
@@ -27,4 +26,8 @@ CONFIG_ENTRY_VERSION = (
 )
 DOMAIN = "ideenergy"
 LOCAL_TZ = ZoneInfo("Europe/Madrid")
-UPDATE_INTERVAL = timedelta(seconds=180)
+
+# Hour and minute (local time, Europe/Madrid) at which the daily data fetch runs.
+# i-DE typically publishes yesterday's data mid-morning; 12:30 is a safe window.
+UPDATE_HOUR = 12
+UPDATE_MINUTE = 30

--- a/custom_components/ideenergy/coordinator.py
+++ b/custom_components/ideenergy/coordinator.py
@@ -17,79 +17,73 @@
 
 from __future__ import annotations
 
-import contextlib
 import enum
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from logging import getLogger
+from time import perf_counter
 
 import ideenergy
 from homeassistant.core import HomeAssistant, dt_util
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant_historical_sensor import HistoricalState
 
-from .const import LOCAL_TZ, UPDATE_INTERVAL
+from .const import DOMAIN, LOCAL_TZ
 from .store import IDeEnergyConfigEntryState
 
 LOGGER = getLogger(__name__)
 
-# Direct reading (accumulated consumption, instant demand)
-DIRECT_READING_LAST_SUCCESS_STORED_STATE_KEY = "direct_reading_last_success"
-DIRECT_READING_LAST_ATTEMPT_STORED_STATE_KEY = "direct_reading_last_attempt"
-DIRECT_READING_LAST_SUCCESS_MAX_AGE = timedelta(hours=6)
-DIRECT_READING_LAST_ATTEMPT_MAX_AGE = timedelta(minutes=5)
 
-# Historical consumption
 HISTORICAL_CONSUMPTION_LAST_SUCCESS_STORED_STATE_KEY = (
     "historical_consumption_last_success"
 )
 HISTORICAL_CONSUMPTION_LAST_ATTEMPT_STORED_STATE_KEY = (
     "historical_consumption_last_attempt"
 )
-HISTORICAL_CONSUMPTION_LAST_SUCCESS_MAX_AGE = timedelta(hours=12)
-HISTORICAL_CONSUMPTION_LAST_ATTEMPT_MAX_AGE = timedelta(minutes=5)
-
-# Historical Generation
 HISTORICAL_GENERATION_LAST_SUCCESS_STORED_STATE_KEY = (
     "historical_generation_last_success"
 )
 HISTORICAL_GENERATION_LAST_ATTEMPT_STORED_STATE_KEY = (
     "historical_generation_last_attempt"
 )
-HISTORICAL_GENERATION_LAST_SUCCESS_MAX_AGE = timedelta(hours=12)
-HISTORICAL_GENERATION_LAST_ATTEMPT_MAX_AGE = timedelta(minutes=5)
+
+
+HISTORICAL_CONSUMPTION_LAST_SUCCESS_MAX_AGE = 2 * 60 * 60
+HISTORICAL_CONSUMPTION_LAST_ATTEMPT_MAX_AGE = 5 * 60  # 5 minutes
+HISTORICAL_GENERATION_LAST_SUCCESS_MAX_AGE = 2 * 60 * 60
+HISTORICAL_GENERATION_LAST_ATTEMPT_MAX_AGE = 5 * 60  # 5 minutes
 
 MEASURE_ACCUMULATED_KEY = "measure_accumulated"
 MEASURE_INSTANT_KEY = "measure_instant"
 
 HISTORICAL_PERIOD_LENGHT = timedelta(days=7)
+SESSION_REFRESH_MIN_INTERVAL_SECONDS = 5 * 60
 
 
 ##
 # IDeEnergyCoordinatorDataSet: types of data that can be registered in the
 # coordinator to be fetched
 class IDeEnergyCoordinatorDataSet(enum.Enum):
-    DIRECT_READING = enum.auto()
     HISTORICAL_CONSUMPTION = enum.auto()
     HISTORICAL_GENERATION = enum.auto()
     POWER_DEMAND_PEAKS = enum.auto()
+    YESTERDAY_TOTAL = enum.auto()
 
 
 ##
 # IDeEnergyDataCoordinatorData: data stored inside the coordinator
 type IDeEnergyDataCoordinatorData = dict[
-    IDeEnergyCoordinatorDataSet, list[HistoricalState] | None
+    IDeEnergyCoordinatorDataSet, list[HistoricalState] | float | None
 ]
 
 
 class IDeEnergyDataCoordinator(DataUpdateCoordinator[IDeEnergyDataCoordinatorData]):
     def __init__(
         self,
-        *,
         hass: HomeAssistant,
         client: ideenergy.Client,
         config_entry_state: IDeEnergyConfigEntryState,
-        update_interval: timedelta = UPDATE_INTERVAL,
+        update_interval: timedelta | None = None,
     ):
         name = f"{client} coordinator" if client else "i-de coordinator"
         super().__init__(hass, LOGGER, name=name, update_interval=update_interval)
@@ -100,17 +94,140 @@ class IDeEnergyDataCoordinator(DataUpdateCoordinator[IDeEnergyDataCoordinatorDat
 
         self._client = client
         self._config_entry_state = config_entry_state
+        self._yesterday_total_last_refresh: datetime | None = None
+        self._yesterday_total_query_date: str | None = None
+        # setup_entry already fetched contract details, so a fresh session exists
+        # at startup and we can skip immediate re-login on first coordinator refresh.
+        self._last_session_refresh_monotonic: float | None = perf_counter()
+
+    @property
+    def yesterday_total_last_refresh(self) -> str | None:
+        if self._yesterday_total_last_refresh is None:
+            return None
+        return self._yesterday_total_last_refresh.isoformat()
+
+    @property
+    def yesterday_total_last_refresh_dt(self) -> datetime | None:
+        """Return the last successful refresh as an aware datetime (Europe/Madrid)."""
+        return self._yesterday_total_last_refresh
+
+    @property
+    def yesterday_total_query_date(self) -> str | None:
+        return self._yesterday_total_query_date
+
+    @staticmethod
+    def _truncate_repr(value, max_len: int = 2000) -> str:
+        text = repr(value)
+        if len(text) <= max_len:
+            return text
+        return f"{text[:max_len]}... <truncated {len(text) - max_len} chars>"
+
+    def _response_summary(self, response) -> dict[str, str | int | float | bool]:
+        summary: dict[str, str | int | float | bool] = {
+            "type": type(response).__name__,
+        }
+
+        for attr in ("status", "status_code", "ok"):
+            if hasattr(response, attr):
+                summary[attr] = getattr(response, attr)
+
+        if isinstance(response, dict):
+            summary["keys_count"] = len(response)
+        elif isinstance(response, (list, tuple, set)):
+            summary["items_count"] = len(response)
+
+        if hasattr(response, "periods"):
+            periods = getattr(response, "periods")
+            try:
+                summary["periods_count"] = len(periods)
+            except TypeError:
+                pass
+
+        if hasattr(response, "demands"):
+            demands = getattr(response, "demands")
+            try:
+                summary["demands_count"] = len(demands)
+            except TypeError:
+                pass
+
+        return summary
+
+    def _response_payload_details(self, response) -> dict[str, str]:
+        details: dict[str, str] = {
+            "repr": self._truncate_repr(response),
+        }
+
+        if isinstance(response, dict):
+            details["dict"] = self._truncate_repr(response)
+        elif isinstance(response, (list, tuple)):
+            details["items"] = self._truncate_repr(response)
+
+        for attr in ("periods", "demands", "body", "text", "content", "json"):
+            if hasattr(response, attr):
+                value = getattr(response, attr)
+                if callable(value):
+                    details[attr] = f"<callable {type(value).__name__}>"
+                else:
+                    details[attr] = self._truncate_repr(value)
+
+        return details
+
+    async def _async_notify(self, title: str, message: str) -> None:
+        """Send a persistent notification to Home Assistant."""
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": title,
+                "message": message,
+                "notification_id": f"{DOMAIN}_consumption_status",
+            },
+        )
+
+    async def _async_api_call(
+        self,
+        api_name: str,
+        afn: Callable,
+        **kwargs,
+    ):
+        """Call the REST client logging request/response for diagnostics."""
+        LOGGER.debug("API request %s: %r", api_name, kwargs)
+        started = perf_counter()
+        try:
+            response = await afn(**kwargs)
+        except Exception:
+            elapsed_ms = (perf_counter() - started) * 1000
+            LOGGER.exception(
+                "API error %s (%.0f ms). request=%r",
+                api_name,
+                elapsed_ms,
+                kwargs,
+            )
+            raise
+
+        elapsed_ms = (perf_counter() - started) * 1000
+        LOGGER.debug(
+            "API response %s (%.0f ms). summary=%s",
+            api_name,
+            elapsed_ms,
+            self._response_summary(response),
+        )
+        LOGGER.debug(
+            "API response %s payload=%s",
+            api_name,
+            self._response_payload_details(response),
+        )
+        return response
 
     def activate_dataset(self, dataset: IDeEnergyCoordinatorDataSet) -> None:
         self.dataset_counter[dataset.name] += 1
         if self.dataset_counter[dataset.name] == 1:
-            LOGGER.info(f"[{self._client}] dataset {dataset.name} enabled")
+            LOGGER.debug(f"dataset {dataset.name} enabled")
             # Fix a better place for this call, it's sub-optimal
             self.hass.async_create_task(self.async_request_refresh())
 
         LOGGER.debug(
-            f"[{self._client}] dataset {dataset.name} ref_count incremented"
-            + f" (count={self.dataset_counter[dataset.name]})"
+            f"dataset {dataset.name} ref_count incremented (count={self.dataset_counter[dataset.name]})"
         )
 
     def deactivate_dataset(self, dataset: IDeEnergyCoordinatorDataSet) -> None:
@@ -118,11 +235,10 @@ class IDeEnergyDataCoordinator(DataUpdateCoordinator[IDeEnergyDataCoordinatorDat
             self.dataset_counter[dataset.name] -= 1
 
         LOGGER.debug(
-            f"[{self._client}] dataset {dataset.name} ref_count decremented"
-            + f" (count={self.dataset_counter[dataset.name]})"
+            f"dataset {dataset.name} ref_count decremented (count={self.dataset_counter[dataset.name]})"
         )
         if self.dataset_counter[dataset.name] == 0:
-            LOGGER.info(f"[{self._client}] dataset {dataset.name} disabled")
+            LOGGER.debug(f"dataset {dataset.name} disabled")
 
     async def _async_setup(self) -> None:
         """Set up the coordinator
@@ -155,73 +271,236 @@ class IDeEnergyDataCoordinator(DataUpdateCoordinator[IDeEnergyDataCoordinatorDat
 
         active_datasets = [k for k, v in self.dataset_counter.items() if v > 0]
         dsstr = ", ".join(active_datasets)
-        LOGGER.debug(f"[{self._client}] datasets enabled: {dsstr}")
+        LOGGER.debug(f"datasets enabled: {dsstr}")
 
         updated_data = {}
 
+        if (
+            self.dataset_counter[IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION.name]
+            > 0
+            or self.dataset_counter[IDeEnergyCoordinatorDataSet.YESTERDAY_TOTAL.name]
+            > 0
+        ):
+            try:
+                historical_consumption, yesterday_consumption = (
+                    await self._async_get_historical_consumption_bundle()
+                )
+            except ideenergy.ClientError:
+                LOGGER.exception(
+                    "HISTORICAL_CONSUMPTION/YESTERDAY_TOTAL: error updating"
+                )
+            else:
+                if (
+                    self.dataset_counter[
+                        IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION.name
+                    ]
+                    > 0
+                ):
+                    updated_data[IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION] = (
+                        historical_consumption
+                    )
+                    if historical_consumption is None:
+                        LOGGER.warning("HISTORICAL_CONSUMPTION: update returned None")
+
+                if (
+                    self.dataset_counter[
+                        IDeEnergyCoordinatorDataSet.YESTERDAY_TOTAL.name
+                    ]
+                    > 0
+                ):
+                    updated_data[IDeEnergyCoordinatorDataSet.YESTERDAY_TOTAL] = (
+                        yesterday_consumption
+                    )
+                    if yesterday_consumption is None:
+                        LOGGER.warning("YESTERDAY_TOTAL: update returned None")
+
         fns = {
-            IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION: self._async_get_historical_consumption,
             IDeEnergyCoordinatorDataSet.HISTORICAL_GENERATION: self._async_get_historical_generation,
             IDeEnergyCoordinatorDataSet.POWER_DEMAND_PEAKS: self._async_get_power_demand_peaks,
-            IDeEnergyCoordinatorDataSet.DIRECT_READING: self._async_get_direct_reading_data,
         }
-        await self._client.renew_session()
-        LOGGER.info(f"[{self._client}] session renewed")
-
         for ds, fn in fns.items():
             if self.dataset_counter[ds.name] > 0:
                 try:
                     updated_data[ds] = await fn()
                 except ideenergy.ClientError:
-                    LOGGER.exception(
-                        f"[{self._client}] error updating dataset '{ds.name}'"
-                    )
+                    LOGGER.exception(f"{ds.name}: error updating")
                     continue
                 if updated_data[ds] is None:
-                    LOGGER.info(
-                        f"[{self._client}] {ds.name}: dataset was not refreshed"
-                    )
-                else:
-                    LOGGER.info(f"[{self._client}] {ds.name}: dataset updated")
+                    LOGGER.warning(f"{ds.name}: update returned None")
 
         data = self.data | {k: v for k, v in updated_data.items() if v is not None}
         return data
 
     async def _async_get_direct_reading_data(self) -> dict[str, int | float]:
-        if self._state_is_too_recent_with_debug(
-            key=DIRECT_READING_LAST_SUCCESS_STORED_STATE_KEY,
-            max_age=DIRECT_READING_LAST_SUCCESS_MAX_AGE,
-            label="DIRECT_READING success check",
-        ):
-            return None
-
-        if self._state_is_too_recent_with_debug(
-            key=DIRECT_READING_LAST_ATTEMPT_STORED_STATE_KEY,
-            max_age=DIRECT_READING_LAST_ATTEMPT_MAX_AGE,
-            label="DIRECT_READING attempt check",
-        ):
-            return None
-
-        async with self._track_state_timestamps(
-            success_key=DIRECT_READING_LAST_SUCCESS_STORED_STATE_KEY,
-            attempt_key=DIRECT_READING_LAST_ATTEMPT_STORED_STATE_KEY,
-        ):
-            data = await self._client.get_measure()
-
+        data = await self._async_api_call(
+            "get_measure",
+            self._client.get_measure,
+        )
         return {
             MEASURE_ACCUMULATED_KEY: data.accumulate,
             MEASURE_INSTANT_KEY: data.instant,
         }
 
     async def _async_get_historical_consumption(self) -> list[HistoricalState] | None:
-        return await self._async_get_historical_generic(
-            self._client.get_historical_consumption,
-            dataset=IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION,
-            last_success_state_key=HISTORICAL_CONSUMPTION_LAST_SUCCESS_STORED_STATE_KEY,
-            last_attempt_state_key=HISTORICAL_CONSUMPTION_LAST_ATTEMPT_STORED_STATE_KEY,
-            last_attempt_max_age=HISTORICAL_CONSUMPTION_LAST_ATTEMPT_MAX_AGE,
-            last_success_max_age=HISTORICAL_CONSUMPTION_LAST_SUCCESS_MAX_AGE,
+        historical_consumption, _ = await self._async_get_historical_consumption_bundle()
+        return historical_consumption
+
+    async def _async_get_historical_consumption_bundle(
+        self,
+    ) -> tuple[list[HistoricalState] | None, float | None]:
+        def as_historical_state(
+            pv: ideenergy.PeriodValue,
+        ) -> HistoricalState | None:
+            dt = pv.end.replace(tzinfo=LOCAL_TZ)
+            last_reset = pv.start.replace(tzinfo=LOCAL_TZ)
+
+            try:
+                return HistoricalState(
+                    state=pv.value / 1000,
+                    timestamp=dt_util.as_timestamp(dt),
+                    attributes={"last_reset": last_reset},
+                )
+            except Exception:
+                LOGGER.error(f"invalid PeriodValue '{pv!r}'")
+                return None
+
+        has_cached_states = (
+            self.data.get(IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION) is not None
         )
+        has_cached_yesterday_consumption = (
+            self.data.get(IDeEnergyCoordinatorDataSet.YESTERDAY_TOTAL) is not None
+        )
+
+        if self.state_timestamp_is_too_recent(
+            HISTORICAL_CONSUMPTION_LAST_SUCCESS_STORED_STATE_KEY,
+            HISTORICAL_CONSUMPTION_LAST_SUCCESS_MAX_AGE,
+        ):
+            if has_cached_states and has_cached_yesterday_consumption:
+                LOGGER.debug(
+                    f"{self._client}: current data for {IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION} is too recent"
+                )
+                return None, None
+
+            LOGGER.debug(
+                "%s: %s marked as recent but no cached states are loaded; forcing refresh",
+                self._client,
+                IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION,
+            )
+
+        if self.state_timestamp_is_too_recent(
+            HISTORICAL_CONSUMPTION_LAST_ATTEMPT_STORED_STATE_KEY,
+            HISTORICAL_CONSUMPTION_LAST_ATTEMPT_MAX_AGE,
+        ):
+            if has_cached_states and has_cached_yesterday_consumption:
+                LOGGER.debug(
+                    f"{self._client}: last attempt for {IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION} is too recent"
+                )
+                return None, None
+
+            LOGGER.debug(
+                "%s: %s last attempt is recent but no cached states are loaded; forcing refresh",
+                self._client,
+                IDeEnergyCoordinatorDataSet.HISTORICAL_CONSUMPTION,
+            )
+
+        local_now = dt_util.now().astimezone(LOCAL_TZ)
+        yesterday_date = (local_now - timedelta(days=1)).date()
+        start = datetime(
+            year=yesterday_date.year,
+            month=yesterday_date.month,
+            day=yesterday_date.day,
+        )
+        end = start + timedelta(days=1)
+        self._yesterday_total_query_date = yesterday_date.strftime("%d-%m-%Y")
+
+        try:
+            now_monotonic = perf_counter()
+            should_refresh_session = (
+                self._last_session_refresh_monotonic is None
+                or now_monotonic - self._last_session_refresh_monotonic
+                >= SESSION_REFRESH_MIN_INTERVAL_SECONDS
+            )
+
+            if should_refresh_session:
+                # i-DE sessions can expire between coordinator updates. Re-login
+                # before requesting consumption to avoid stale auth state.
+                await self._async_api_call(
+                    "login",
+                    self._client.login,
+                )
+
+                # Contract context is session-scoped on i-DE. Refresh it after
+                # login so consumption calls target the configured contract.
+                await self._async_api_call(
+                    "get_contract_details",
+                    self._client.get_contract_details,
+                )
+                self._last_session_refresh_monotonic = perf_counter()
+            else:
+                LOGGER.debug(
+                    "Skipping session refresh: previous login+contract refresh was %.1f seconds ago",
+                    now_monotonic - self._last_session_refresh_monotonic,
+                )
+
+            data = await self._async_api_call(
+                "get_historical_consumption",
+                self._client.get_historical_consumption,
+                start=start,
+                end=end,
+            )
+        except Exception:
+            await self.async_save_timestamp_at_state(
+                HISTORICAL_CONSUMPTION_LAST_ATTEMPT_STORED_STATE_KEY
+            )
+            error_time = dt_util.now().astimezone(LOCAL_TZ).strftime("%d/%m/%Y %H:%M")
+            await self._async_notify(
+                title="i-DE: Error al obtener consumo",
+                message=(
+                    f"No se pudieron obtener los datos de consumo de i-DE.\n"
+                    f"Fecha consultada: {self._yesterday_total_query_date}\n"
+                    f"Hora del error: {error_time}"
+                ),
+            )
+            raise
+
+        await self.async_save_timestamp_at_state(
+            HISTORICAL_CONSUMPTION_LAST_SUCCESS_STORED_STATE_KEY
+        )
+        self._yesterday_total_last_refresh = dt_util.now().astimezone(LOCAL_TZ)
+
+        periods = getattr(data, "periods", None)
+        if periods is None:
+            periods = []
+
+        if len(periods) != 24:
+            LOGGER.warning(
+                "get_historical_consumption returned %d periods for yesterday (expected 24)",
+                len(periods),
+            )
+
+        hist_states = [as_historical_state(pv) for pv in periods]
+        hist_states = [hs for hs in hist_states if hs is not None]
+
+        total_raw = getattr(data, "total", None)
+        yesterday_consumption = float(total_raw) if total_raw is not None else None
+
+        refresh_time = self._yesterday_total_last_refresh.strftime("%d/%m/%Y %H:%M")
+        periods_ok = len(hist_states)
+        total_str = (
+            f"{yesterday_consumption:.0f} Wh" if yesterday_consumption is not None else "desconocido"
+        )
+        await self._async_notify(
+            title="i-DE: Consumo actualizado",
+            message=(
+                f"Datos de consumo cargados correctamente.\n"
+                f"Fecha consultada: {self._yesterday_total_query_date}\n"
+                f"Periodos recibidos: {periods_ok}/24\n"
+                f"Total ayer: {total_str}\n"
+                f"Hora de actualización: {refresh_time}"
+            ),
+        )
+
+        return hist_states, yesterday_consumption
 
     async def _async_get_historical_generation(self) -> list[HistoricalState] | None:
         return await self._async_get_historical_generic(
@@ -247,10 +526,13 @@ class IDeEnergyDataCoordinator(DataUpdateCoordinator[IDeEnergyDataCoordinatorDat
                     # attributes={"last_reset": last_reset},
                 )
             except Exception:
-                LOGGER.exception(f"[{self._client}] invalid DemandAtInstant '{dai!r}'")
+                LOGGER.error(f"invalid DemandAtInstant '{dai!r}'")
                 return None
 
-        data = await self._client.get_historical_power_demand()
+        data = await self._async_api_call(
+            "get_historical_power_demand",
+            self._client.get_historical_power_demand,
+        )
         hist_states = [
             historical_power_demand_as_historical_state(dai) for dai in data.demands
         ]
@@ -263,33 +545,11 @@ class IDeEnergyDataCoordinator(DataUpdateCoordinator[IDeEnergyDataCoordinatorDat
         afn: Callable,
         *,
         dataset=IDeEnergyCoordinatorDataSet,
-        last_attempt_max_age: timedelta,
+        last_attempt_max_age: float,
         last_attempt_state_key: str,
-        last_success_max_age: timedelta,
+        last_success_max_age: float,
         last_success_state_key: str,
     ) -> list[HistoricalState] | None:
-        if self._state_is_too_recent_with_debug(
-            key=last_success_state_key,
-            max_age=last_success_max_age,
-            label=f"{dataset.name} success check",
-        ):
-            return None
-
-        if self._state_is_too_recent_with_debug(
-            key=last_attempt_state_key,
-            max_age=last_attempt_max_age,
-            label=f"{dataset.name} attempt check",
-        ):
-            return None
-
-        end = datetime.today()
-        start = end - HISTORICAL_PERIOD_LENGHT
-
-        async with self._track_state_timestamps(
-            success_key=last_success_state_key,
-            attempt_key=last_attempt_state_key,
-        ):
-            data = await afn(start=start, end=end)
 
         def as_historical_state(
             pv: ideenergy.PeriodValue,
@@ -304,70 +564,77 @@ class IDeEnergyDataCoordinator(DataUpdateCoordinator[IDeEnergyDataCoordinatorDat
                     attributes={"last_reset": last_reset},
                 )
             except Exception:
-                LOGGER.error(f"[{self._client}] invalid PeriodValue '{pv!r}'")
+                LOGGER.error(f"invalid PeriodValue '{pv!r}'")
                 return None
+
+        current_data = self.data.get(dataset)
+        has_cached_states = current_data is not None
+
+        if self.state_timestamp_is_too_recent(
+            last_success_state_key,
+            last_success_max_age,
+        ):
+            if not has_cached_states:
+                LOGGER.debug(
+                    "%s: %s marked as recent but no cached states are loaded; forcing refresh",
+                    self._client,
+                    dataset,
+                )
+            else:
+                LOGGER.debug(f"{self._client}: current data for {dataset} is too recent")
+                return None
+
+        if self.state_timestamp_is_too_recent(
+            last_attempt_state_key,
+            last_attempt_max_age,
+        ):
+            if has_cached_states:
+                LOGGER.debug(f"{self._client}: last attempt for {dataset} is too recent")
+                return None
+
+            LOGGER.debug(
+                "%s: %s last attempt is recent but no cached states are loaded; forcing refresh",
+                self._client,
+                dataset,
+            )
+
+        end = datetime.today()
+        start = end - HISTORICAL_PERIOD_LENGHT
+
+        api_name = getattr(afn, "__name__", repr(afn))
+        try:
+            data = await self._async_api_call(
+                api_name,
+                afn,
+                start=start,
+                end=end,
+            )
+        except Exception:
+            await self.async_save_timestamp_at_state(last_attempt_state_key)
+            raise
+
+        await self.async_save_timestamp_at_state(last_success_state_key)
 
         hist_states = [as_historical_state(pv) for pv in data.periods]
         hist_states = [hs for hs in hist_states if hs is not None]
         return hist_states
 
-    async def _async_save_state_timestamp(
+    async def async_save_timestamp_at_state(
         self, key: str, timestamp: float | None = None
     ) -> None:
-        timestamp = timestamp or dt_util.as_timestamp(dt_util.now())
+        timestamp = timestamp or dt_util.as_timestamp(datetime.now())
         self._config_entry_state.data[key] = timestamp
         await self._config_entry_state.async_save()
 
-    @contextlib.asynccontextmanager
-    async def _track_state_timestamps(self, *, success_key: str, attempt_key: str):
-        """Context manager to track state timestamps on success/failure."""
-        try:
-            yield
-        except Exception:
-            await self._async_save_state_timestamp(attempt_key)
-            raise
-        else:
-            await self._async_save_state_timestamp(success_key)
-
-    def _state_is_too_recent_with_debug(
-        self, *, key: str, max_age: timedelta, label: str
-    ) -> bool:
-        """Check if max_age timedelta has passed since key was last updated.
-
-        Args:
-            key: The state key to check
-            max_age: The maximum age timedelta
-            label: Debug label for logging
-
-        Returns:
-            True if not enough time has passed (too recent), False if enough time has passed
-        """
-        now_dt = dt_util.now()
-        max_age_seconds = max_age.total_seconds()
+    def state_timestamp_is_too_recent(self, key: str, max_age: float) -> bool:
+        now_ts = dt_util.as_timestamp(datetime.now())
 
         try:
-            prev_ts = float(self._config_entry_state.data[key])
-        except TypeError, ValueError, KeyError:
-            LOGGER.debug(f"[{self._client}] {label}: no previous timestamp found")
-            return False
+            prev = float(self._config_entry_state.data[key])
+        except (TypeError, ValueError, KeyError):
+            prev = 0
 
-        prev_dt = dt_util.as_local(datetime.fromtimestamp(prev_ts))
-        elapsed = now_dt - prev_dt
-        is_too_recent = elapsed.total_seconds() <= max_age_seconds
-
-        if is_too_recent:
-            fulfillment_dt = prev_dt + max_age
-            remaining_seconds = max_age_seconds - elapsed.total_seconds()
-
-            LOGGER.debug(
-                f"[{self._client}] {label}: too recent - "
-                f"last check: {prev_dt.isoformat()}, "
-                f"required interval: {max_age}, "
-                f"remaining time: {remaining_seconds:.0f}s "
-                f"(will be ready at {fulfillment_dt.isoformat()})"
-            )
-
-        return is_too_recent
+        return now_ts - prev <= max_age
 
 
 # def period_item_with_tz_info(item):

--- a/custom_components/ideenergy/manifest.json
+++ b/custom_components/ideenergy/manifest.json
@@ -1,23 +1,20 @@
 {
   "domain": "ideenergy",
   "name": "i-DE Energy Monitor",
-  "after_dependencies": [
-    "recorder"
-  ],
   "codeowners": [
-    "@ldotlopez"
+    "@marrubio"
   ],
   "config_flow": true,
   "dependencies": [
     "statistics"
   ],
-  "documentation": "https://github.com/ldotlopez/ha-ideenergy",
+  "documentation": "https://github.com/marrubio/ha-ideenergy",
   "integration_type": "device",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/ldotlopez/ha-ideenergy/issues",
+  "issue_tracker": "https://github.com/marrubio/ha-ideenergy/issues",
   "requirements": [
     "ideenergy>=2.0.1.dev3",
     "homeassistant-historical-sensor==3.0.0a4"
   ],
-  "version": "3.0.0a1"
+  "version": "3.0.0alpha2"
 }

--- a/custom_components/ideenergy/sensor.py
+++ b/custom_components/ideenergy/sensor.py
@@ -16,8 +16,12 @@
 # USA.
 
 
+# TODO:
+# Maybe we need to mark some function as callback but I'm not sure whose.
+
+
 import itertools
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import cached_property
 from logging import getLogger
 from math import ceil
@@ -25,15 +29,16 @@ from typing import cast
 
 from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
 from homeassistant.components.sensor import (
-    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback, dt_util
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 from homeassistant_historical_sensor import (
@@ -42,11 +47,7 @@ from homeassistant_historical_sensor import (
     hass_get_last_statistic,
 )
 
-from .coordinator import (
-    MEASURE_ACCUMULATED_KEY,
-    IDeEnergyCoordinatorDataSet,
-    IDeEnergyDataCoordinator,
-)
+from .coordinator import IDeEnergyCoordinatorDataSet, IDeEnergyDataCoordinator
 from .data import IntegrationIDeEnergyConfigEntry
 
 PLATFORM = "sensor"
@@ -63,6 +64,7 @@ class IDeEnergySensor(CoordinatorEntity, HistoricalSensor, SensorEntity):
     def __init__(
         self,
         *args,
+        hass: HomeAssistant,
         device_info: DeviceInfo,
         **kwargs,
     ):
@@ -176,7 +178,7 @@ class IDeEnergySensor(CoordinatorEntity, HistoricalSensor, SensorEntity):
 
         try:
             total_accumulated = extract_last_sum(latest)
-        except KeyError, ValueError:
+        except (KeyError, ValueError):
             LOGGER.error(
                 f"{self.entity_id}: [bug] statistics broken (lastest={latest!r})"
             )
@@ -219,68 +221,6 @@ class IDeEnergySensor(CoordinatorEntity, HistoricalSensor, SensorEntity):
         return ret
 
 
-class AccumulatedConsumption(RestoreSensor, CoordinatorEntity, SensorEntity):
-    I_DE_PLATFORM = PLATFORM
-    I_DE_ENTITY_NAME = "Accumulated Consumption"
-    I_DE_DATA_SET = {IDeEnergyCoordinatorDataSet.DIRECT_READING}
-
-    coordinator: IDeEnergyDataCoordinator
-
-    def __init__(
-        self,
-        *args,
-        device_info: DeviceInfo,
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
-
-        self._attr_has_entity_name = True
-        self._attr_name = self.I_DE_ENTITY_NAME
-        self._attr_unique_id = _build_entity_unique_id(
-            device_info, self.I_DE_ENTITY_NAME
-        )
-        self._attr_device_class = SensorDeviceClass.ENERGY
-        self._attr_device_info = device_info
-        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-        self._attr_native_value = None
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        reading = self.coordinator.data.get(IDeEnergyCoordinatorDataSet.DIRECT_READING)
-        if reading and MEASURE_ACCUMULATED_KEY in reading:
-            self._attr_native_value = reading[MEASURE_ACCUMULATED_KEY]
-            self.async_write_ha_state()
-
-    # ==
-    # Entity
-    # ==
-    async def async_added_to_hass(self) -> None:
-        LOGGER.info(f"{self.entity_id} added to hass")
-        await super().async_added_to_hass()
-
-        for x in self.I_DE_DATA_SET:
-            self.coordinator.activate_dataset(x)
-
-        await self.coordinator.async_request_refresh()
-        LOGGER.info(f"{self.entity_id} updated historical")
-
-        prev = await self.async_get_last_sensor_data()
-        LOGGER.debug(f"{self.entity_id} last sensor data: {prev!r}")
-        if prev is not None and prev.native_value is not None:
-            self._attr_native_value = prev.native_value
-            LOGGER.debug(f"{self.entity_id} restored previous value of {self.state}")
-        else:
-            LOGGER.debug(f"{self.entity_id} no previous sensor data to restore")
-
-    async def async_will_remove_from_hass(self) -> None:
-        for x in self.I_DE_DATA_SET:
-            self.coordinator.deactivate_dataset(x)
-
-        await super().async_will_remove_from_hass()
-
-
 class HistoricalConsumption(IDeEnergySensor):
     I_DE_PLATFORM = PLATFORM
     I_DE_ENTITY_NAME = "Historical Consumption"
@@ -302,8 +242,6 @@ class HistoricalGeneration(IDeEnergySensor):
     I_DE_ENTITY_NAME = "Historical Generation"
     I_DE_DATA_SET = {IDeEnergyCoordinatorDataSet.HISTORICAL_GENERATION}
 
-    _attr_entity_registry_enabled_default = False
-
     def get_statistic_metadata(self):
         meta = super().get_statistic_metadata()
         meta["unit_class"] = SensorDeviceClass.ENERGY
@@ -313,6 +251,70 @@ class HistoricalGeneration(IDeEnergySensor):
     @property
     def historical_states(self) -> list[HistoricalState] | None:
         return self.coordinator.data[IDeEnergyCoordinatorDataSet.HISTORICAL_GENERATION]
+
+
+class YesterdayTotal(CoordinatorEntity, SensorEntity):
+    coordinator: IDeEnergyDataCoordinator
+
+    def __init__(
+        self,
+        *args,
+        hass: HomeAssistant,
+        device_info: DeviceInfo,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        self._attr_has_entity_name = True
+        self._attr_name = "Yesterday Total"
+        self._attr_device_info = device_info
+
+        self._attr_unique_id = _build_entity_unique_id(
+            device_info, "Yesterday Total"
+        )
+        self._attr_device_class = SensorDeviceClass.ENERGY
+        self._attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_extra_state_attributes = {
+            "LAST_REFRESH": None,
+            "YESTERDAY_DATE": None,
+        }
+
+    async def async_added_to_hass(self) -> None:
+        LOGGER.info(f"{self.entity_id} added to hass")
+        await super().async_added_to_hass()
+        self.coordinator.activate_dataset(
+            IDeEnergyCoordinatorDataSet.YESTERDAY_TOTAL
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_will_remove_from_hass(self) -> None:
+        self.coordinator.deactivate_dataset(
+            IDeEnergyCoordinatorDataSet.YESTERDAY_TOTAL
+        )
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._attr_extra_state_attributes = {
+            "LAST_REFRESH": self.coordinator.yesterday_total_last_refresh,
+            "YESTERDAY_DATE": self.coordinator.yesterday_total_query_date,
+        }
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self) -> float | None:
+        return cast(
+            float | None,
+            self.coordinator.data[IDeEnergyCoordinatorDataSet.YESTERDAY_TOTAL],
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        return {
+            "LAST_REFRESH": self.coordinator.yesterday_total_last_refresh,
+            "YESTERDAY_DATE": self.coordinator.yesterday_total_query_date,
+        }
 
 
 ##
@@ -354,17 +356,69 @@ class HistoricalGeneration(IDeEnergySensor):
 #         ]  # ty:ignore[non-subscriptable]
 
 
+class LastRefreshTime(CoordinatorEntity, SensorEntity):
+    """Sensor that exposes the last successful data fetch timestamp."""
+
+    coordinator: IDeEnergyDataCoordinator
+
+    def __init__(
+        self,
+        *args,
+        hass: HomeAssistant,
+        device_info: DeviceInfo,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        self._attr_has_entity_name = True
+        self._attr_name = "Last Refresh Time"
+        self._attr_device_info = device_info
+        self._attr_unique_id = _build_entity_unique_id(device_info, "Last Refresh Time")
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_icon = "mdi:clock-check-outline"
+
+    @property
+    def native_value(self) -> datetime | None:
+        return self.coordinator.yesterday_total_last_refresh_dt
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: IntegrationIDeEnergyConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    IDeClasses = [AccumulatedConsumption, HistoricalConsumption, HistoricalGeneration]
+    # entity_description = (
+    #     SensorEntityDescription(
+    #         key="ideenergy",
+    #         name="i-de energy",
+    #         icon="mdi:energy",
+    #     ),
+    # )
+
+    entity_registry = er.async_get(hass)
+    old_unique_ids = {
+        _build_entity_unique_id(entry.runtime_data.device_info, "Yesterday Power"),
+        _build_entity_unique_id(entry.runtime_data.device_info, "Yesterday Consumption"),
+    }
+    for registry_entry in er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    ):
+        if registry_entry.unique_id in old_unique_ids:
+            entity_registry.async_remove(registry_entry.entity_id)
+
+    IDeClasses = [
+        HistoricalConsumption,
+        HistoricalGeneration,
+        YesterdayTotal,
+        LastRefreshTime,
+    ]
     async_add_entities(
         [
             IDeClass(
+                hass=hass,
                 coordinator=entry.runtime_data.coordinator,
                 device_info=entry.runtime_data.device_info,
+                # entity_description=entity_description,
             )
             for IDeClass in IDeClasses
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
 ]
 authors = [
   {name = "Luis López", email = "luis@cuarentaydos.com"},
+  {name = "Mario Rubio", email = "marugi@gmail.com"},
 ]
 readme = "README.md"
 description ="Historical sensors for HomeAssistant"


### PR DESCRIPTION
Se elimina la referencia al consumo instantáneo.
Ahora se obtienen 24 lecturas horarias del día anterior.
Se añade que los datos suelen estar disponibles desde las 10:00 del día siguiente.
Se programa la actualización a las 12:30 para asegurar disponibilidad.
Se incorporan las nuevas entidades:
- Consumo total de ayer.
- Fecha de última recarga del consumo.

Se realiza el envío de notificación a Home Assistant con el resultado de la llamada al API.
**La obtención de datos del API  de I-de se hace solo al arranque de la integración y una vez al día a las 12:30.**